### PR TITLE
FIXED: REPL links being broken in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the render prop pattern in React.
 
 ### Example
 
-[Open in REPL](https://svelte.dev/repl/5ba56f98dc7f4911818ec5617c6b3024?version=3.19.0)
+[Open in REPL](https://svelte.dev/repl/5ba56f98dc7f4911818ec5617c6b3024?version=3)
 
 ```html
 <script>
@@ -341,7 +341,7 @@ With no options passed, `<Field />` will default to an HTML `<input />` element.
 
 ### Example
 
-[Open in REPL](https://svelte.dev/repl/47dade3d6be14be685c0347e0d525de7?version=3.19.1)
+[Open in REPL](https://svelte.dev/repl/47dade3d6be14be685c0347e0d525de7?version=3)
 
 **MyInput.svelte**
 


### PR DESCRIPTION
Fixes the `$$restProps is an illegal variable name (Field.svelte:53:16)` error on the REPL links by passing `3` as the version (which redirects to the latest 3.x.x version)