### PR TITLE
Removing some redundancy

### DIFF
--- a/src/Field.svelte
+++ b/src/Field.svelte
@@ -61,6 +61,6 @@
         form={sveltikBag}
         meta={{ initialError: initialErrors[name], initialTouched: initialTouched[name], initialValue: initialValues[name], initialWarning: initialWarnings[name], value: $values[name], touched: $touched[name], error: $errors[name], warning: $warnings[name] }}
     >
-        <input {name} value={$values[name]} {type} {...$$restProps} on:blur={handleBlur} on:input={handleInput} />
+        <input {name} {type} value={$values[name]} {...$$restProps} on:blur={handleBlur} on:input={handleInput} />
     </slot>
 {/if}

--- a/src/Field.svelte
+++ b/src/Field.svelte
@@ -61,17 +61,6 @@
         form={sveltikBag}
         meta={{ initialError: initialErrors[name], initialTouched: initialTouched[name], initialValue: initialValues[name], initialWarning: initialWarnings[name], value: $values[name], touched: $touched[name], error: $errors[name], warning: $warnings[name] }}
     >
-        {#if type === 'number'}
-            <input
-                {name}
-                type="number"
-                value={$values[name]}
-                {...$$restProps}
-                on:blur={handleBlur}
-                on:input={handleInput}
-            />
-        {:else}
-            <input {name} value={$values[name]} {type} {...$$restProps} on:blur={handleBlur} on:input={handleInput} />
-        {/if}
+        <input {name} value={$values[name]} {type} {...$$restProps} on:blur={handleBlur} on:input={handleInput} />
     </slot>
 {/if}

--- a/tests/field.test.js
+++ b/tests/field.test.js
@@ -46,7 +46,7 @@ test('input', async () => {
     const { html } = await render('./tests/fixtures/as-input.svelte')
 
     expect(clean(html)).toMatchInlineSnapshot(
-        `"<input name=\\"color\\" value=\\"undefined\\" type=\\"text\\">"`,
+        `"<input name=\\"color\\" type=\\"text\\" value=\\"undefined\\">"`,
     )
 })
 


### PR DESCRIPTION
Let me know if there is a reason for the explicit need of the `type='number'` input element rather than the all inclusive input field right below it