### PR TITLE
Fix repository format in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sveltik",
     "version": "0.1.13",
-    "repository": "git@github.com:nathancahill/sveltik.git",
+    "repository": "github:nathancahill/sveltik",
     "author": "Nathan Cahill <nathan@nathancahill>",
     "svelte": "src/index.js",
     "module": "dist/index.mjs",


### PR DESCRIPTION
This should provide a link to this repo on the npm page https://www.npmjs.com/package/sveltik.

See https://docs.npmjs.com/files/package.json#repository